### PR TITLE
Feat: 게시글 목록 무한 스크롤 기능 구현

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -2,10 +2,10 @@ import axios, { AxiosError } from 'axios';
 import { NewComment, NewPost } from 'global/types';
 
 const board = {
-  getPostList: async (start?: number, count?: number) => {
+  getPostList: async (start: number, count: number) => {
     try {
       let postListData;
-      if (start && count) {
+      if (start >= 0 && count >= 0) {
         postListData = await axios.get(`/post/list?start=${start}&count=${count}`);
       } else {
         postListData = await axios.get(`/post/list`);

--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -2,9 +2,14 @@ import axios, { AxiosError } from 'axios';
 import { NewComment, NewPost } from 'global/types';
 
 const board = {
-  getPostList: async () => {
+  getPostList: async (start?: number, count?: number) => {
     try {
-      const postListData = await axios.get('/post/list');
+      let postListData;
+      if (start && count) {
+        postListData = await axios.get(`/post/list?start=${start}&count=${count}`);
+      } else {
+        postListData = await axios.get(`/post/list`);
+      }
       return postListData.data.data;
     } catch {
       throw {

--- a/src/components/common/Browser.tsx
+++ b/src/components/common/Browser.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, forwardRef, ForwardedRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
@@ -14,7 +14,7 @@ interface BrowserProps {
   children?: React.ReactNode;
 }
 
-export const Browser = ({ children }: BrowserProps) => {
+export const Browser = forwardRef(({ children }: BrowserProps, ref: ForwardedRef<HTMLDivElement>) => {
   const MENUS = ['File', 'Edit', 'View', 'Go', 'Favorite', 'Tools', 'Help'];
   return (
     <Wrapper>
@@ -31,14 +31,13 @@ export const Browser = ({ children }: BrowserProps) => {
         ))}
       </MenuBar>
       <AddressBar />
-      <Window>{children}</Window>
+      <Window ref={ref}>{children}</Window>
     </Wrapper>
   );
-};
+});
 
 const AddressBar = () => {
   const navigate = useNavigate();
-
   const handleButtonRestore = useCallback((pageMoveButtonName: string) => {
     switch (pageMoveButtonName) {
       case 'previous':

--- a/src/components/common/NoPost.tsx
+++ b/src/components/common/NoPost.tsx
@@ -4,18 +4,24 @@ import NoPostImg from 'assets/no_post_img.png';
 export const NoPost = () => {
   return (
     <NoPostWrapper>
-      <NoPostImage src={NoPostImg} />
-      <div>No Post</div>
+      <NoPostBox>
+        <NoPostImage src={NoPostImg} />
+        <div>No Post</div>
+      </NoPostBox>
     </NoPostWrapper>
   );
 };
 
 const NoPostWrapper = styled.div`
+  display: table-cell;
+`;
+
+const NoPostBox = styled.div`
+  height: 100%;
   display: flex;
-  align-items: center;
   flex-direction: column;
   justify-content: center;
-  min-height: 100%;
+  align-items: center;
 `;
 
 const NoPostImage = styled.img`

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+export const useIntersectionObserver = (
+  intersectRef: React.RefObject<HTMLDivElement>,
+  options: {
+    root: Element | null;
+    rootMargin: string;
+    threshold: number;
+  },
+) => {
+  const [isIntersect, setIsIntersect] = useState<boolean>(false);
+  const { root, rootMargin = '0px', threshold } = options;
+
+  const handleIntersect: IntersectionObserverCallback = (entries) => {
+    const target = entries[0];
+    if (target.isIntersecting) {
+      setIsIntersect(true);
+    } else {
+      setIsIntersect(false);
+    }
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersect, {
+      root: root,
+      rootMargin: rootMargin,
+      threshold: threshold,
+    });
+
+    if (intersectRef.current) observer.observe(intersectRef.current);
+
+    return () => observer.disconnect();
+  }, [intersectRef, root, rootMargin, threshold]);
+
+  return {
+    isIntersect,
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import axios from 'axios';
 import App from 'App';
@@ -8,8 +7,8 @@ axios.defaults.baseURL = process.env.REACT_APP_API_URL;
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
+  <>
     <GlobalStyle />
     <App />
-  </React.StrictMode>,
+  </>,
 );

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -23,10 +23,11 @@ export const ListPage = () => {
     rootMargin: '50px',
     threshold: 0.01,
   });
+  const COUNT = 5;
 
   const fetchPostList = async () => {
     try {
-      const fetchedData = await board.getPostList(postListPage, 5);
+      const fetchedData = await board.getPostList(postListPage, COUNT);
       if (fetchedData.length === 0) {
         setContinueFetching(false);
         return;
@@ -46,7 +47,7 @@ export const ListPage = () => {
   useEffect(() => {
     if (isIntersect && postListPage >= 0) {
       setPostListPage((prev) => {
-        return prev + 5;
+        return prev + COUNT;
       });
     }
   }, [isIntersect]);

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { Browser } from 'components/common/Browser';
@@ -9,25 +9,42 @@ import { auth } from 'api/auth';
 import { board } from 'api/board';
 import { PostItem } from 'components/board/PostItem';
 import { NoPost } from 'components/common/NoPost';
+import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
 export const ListPage = () => {
-  const [postList, setPostList] = useState<Post[]>();
+  const [postList, setPostList] = useState<Post[]>([]);
+  const [start, setStart] = useState<number>(0);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    fetchPostList();
-  }, []);
+  const intersectRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const { isIntersect } = useIntersectionObserver(intersectRef, {
+    root: rootRef.current,
+    rootMargin: '50px',
+    threshold: 0.01,
+  });
 
   const fetchPostList = async () => {
     try {
-      const fetchedData = await board.getPostList();
-      setPostList(fetchedData);
+      const fetchedData = await board.getPostList(start, 5);
+      setPostList((prev) => [...prev, ...fetchedData]);
     } catch (err) {
       const error = err as CustomError;
       alert(error.message);
       navigate('/');
     }
   };
+
+  useEffect(() => {
+    fetchPostList();
+  }, [start]);
+
+  useEffect(() => {
+    if (isIntersect && start >= 0) {
+      setStart((prev) => {
+        return prev + 5;
+      });
+    }
+  }, [isIntersect]);
 
   const moveToPost = useCallback(
     (postIdx: number) => {
@@ -52,7 +69,7 @@ export const ListPage = () => {
   return (
     <Layout>
       <BrowserWrapper>
-        <Browser>
+        <Browser ref={rootRef}>
           <ButtonWrapper>
             <Button type="button" name="Create Post" restoreHandler={handleCreatePostButtonClick} />
           </ButtonWrapper>
@@ -63,6 +80,7 @@ export const ListPage = () => {
               <NoPost />
             )}
           </ListWrapper>
+          {<div ref={intersectRef}>Loading...</div>}
         </Browser>
       </BrowserWrapper>
     </Layout>
@@ -85,5 +103,4 @@ const ListWrapper = styled.div`
   display: table;
   width: 100%;
   height: inherit;
-  background: red;
 `;

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -82,5 +82,8 @@ const ButtonWrapper = styled.div`
 
 const ListWrapper = styled.div`
   padding: 0.5rem 2.5rem;
-  height: 100%;
+  display: table;
+  width: 100%;
+  height: inherit;
+  background: red;
 `;

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -13,7 +13,7 @@ import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
 export const ListPage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
-  const [start, setStart] = useState<number>(0);
+  const [postListPage, setPostListPage] = useState<number>(0);
   const navigate = useNavigate();
   const intersectRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -25,7 +25,7 @@ export const ListPage = () => {
 
   const fetchPostList = async () => {
     try {
-      const fetchedData = await board.getPostList(start, 5);
+      const fetchedData = await board.getPostList(postListPage, 5);
       setPostList((prev) => [...prev, ...fetchedData]);
     } catch (err) {
       const error = err as CustomError;
@@ -36,11 +36,11 @@ export const ListPage = () => {
 
   useEffect(() => {
     fetchPostList();
-  }, [start]);
+  }, [postListPage]);
 
   useEffect(() => {
-    if (isIntersect && start >= 0) {
-      setStart((prev) => {
+    if (isIntersect && postListPage >= 0) {
+      setPostListPage((prev) => {
         return prev + 5;
       });
     }

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -14,6 +14,7 @@ import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 export const ListPage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
   const [postListPage, setPostListPage] = useState<number>(0);
+  const [continueFetching, setContinueFetching] = useState<boolean>(true);
   const navigate = useNavigate();
   const intersectRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -26,6 +27,10 @@ export const ListPage = () => {
   const fetchPostList = async () => {
     try {
       const fetchedData = await board.getPostList(postListPage, 5);
+      if (fetchedData.length === 0) {
+        setContinueFetching(false);
+        return;
+      }
       setPostList((prev) => [...prev, ...fetchedData]);
     } catch (err) {
       const error = err as CustomError;
@@ -80,7 +85,7 @@ export const ListPage = () => {
               <NoPost />
             )}
           </ListWrapper>
-          {<div ref={intersectRef}>Loading...</div>}
+          {continueFetching && <div ref={intersectRef}>Loading...</div>}
         </Browser>
       </BrowserWrapper>
     </Layout>

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -66,4 +66,5 @@ const BrowserWrapper = styled.div`
 const ListWrapper = styled.div`
   padding: 0.5rem 2.5rem;
   height: 100%;
+  min-height: 100%;
 `;

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -64,7 +64,8 @@ const BrowserWrapper = styled.div`
 `;
 
 const ListWrapper = styled.div`
-  padding: 0.5rem 2.5rem;
-  height: 100%;
-  min-height: 100%;
+  display: table;
+  width: 100%;
+  height: inherit;
+  background: red;
 `;

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -67,5 +67,4 @@ const ListWrapper = styled.div`
   display: table;
   width: 100%;
   height: inherit;
-  background: red;
 `;


### PR DESCRIPTION
# What is this PR?🔍
- 게시글 목록 무한 스크롤 기능 구현

# Changes✨
- 게시글 목록을 fetch할 때 사용하는 getPostList 메소드에 start, count를 parameter로 추가
  - 두 값이 모두 0 이상일 경우 query string으로 start, count 값을 주입하여 API 통신
  - 그렇지 않을 경우 기존과 동일하게 전체 목록 fetch
- 게시글 목록의 끝이 화면에 나타나는(교차) 여부를 관찰하는 용도로 사용될 useIntersectionObserver custom hook 생성하여 활용
- useIntersectionObserver를 사용하여 무한 스크롤 구현

# Screenshot📸
![pr_image](https://user-images.githubusercontent.com/67324487/218274254-1766e4bc-135a-4ee3-b920-23e50c9c0b9f.gif)

# To reviewers🕵🏻‍♂️
-

Closes #issue.no