### PR TITLE
Feat: 댓글 목록 무한 스크롤 기능 구현

### DIFF
--- a/src/api/board.ts
+++ b/src/api/board.ts
@@ -29,6 +29,22 @@ const board = {
       };
     }
   },
+  getCommentList: async (postIdx: string, start: number, count: number) => {
+    try {
+      let commentListData;
+      if (start >= 0 && count >= 0) {
+        commentListData = await axios.get(`/post/${postIdx}/comment/list?start=${start}&count=${count}`);
+      } else {
+        commentListData = await axios.get(`/post/${postIdx}/comment`);
+      }
+      return commentListData.data.data;
+    } catch {
+      throw {
+        code: 500,
+        message: '서버로부터 댓글 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+      };
+    }
+  },
   createPost: async (data: NewPost) => {
     try {
       await axios.post(`/post`, data, { withCredentials: true });

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -26,7 +26,7 @@ const LayoutWrapper = styled.div`
 
 const Main = styled.main`
   background-color: #008080;
-  min-height: calc(100vh - ${theme.layout.bottomNavBarHeight});
+  height: calc(100vh - ${theme.layout.bottomNavBarHeight});
   display: flex;
 `;
 

--- a/src/global/types.ts
+++ b/src/global/types.ts
@@ -19,7 +19,7 @@ export interface Post {
     member_nickname: string;
   };
   comments?: Comment[];
-  comments_count: number;
+  comments_count?: number;
 }
 
 export interface Comment {
@@ -31,6 +31,9 @@ export interface Comment {
   };
   createdAt: Date;
   updatedAt: Date;
+  deletedAt?: Date | null;
+  member_idx?: number;
+  post_idx?: number;
 }
 
 export interface Member {

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -11,6 +11,10 @@ import { PostItem } from 'components/board/PostItem';
 import { NoPost } from 'components/common/NoPost';
 import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
+interface PostListBottomProps {
+  continueFetching: boolean;
+}
+
 export const ListPage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
   const [postListPage, setPostListPage] = useState<number>(0);
@@ -41,7 +45,9 @@ export const ListPage = () => {
   };
 
   useEffect(() => {
-    fetchPostList();
+    if (continueFetching) {
+      fetchPostList();
+    }
   }, [postListPage]);
 
   useEffect(() => {
@@ -86,7 +92,9 @@ export const ListPage = () => {
               <NoPost />
             )}
           </ListWrapper>
-          {continueFetching && <div ref={intersectRef}>Loading...</div>}
+          <PostListBottom continueFetching={continueFetching} ref={intersectRef}>
+            Loading...
+          </PostListBottom>
         </Browser>
       </BrowserWrapper>
     </Layout>
@@ -111,4 +119,12 @@ const ListWrapper = styled.div`
   table-layout: fixed;
   width: 100%;
   height: inherit;
+`;
+
+const PostListBottom = styled.div<PostListBottomProps>`
+  ${({ continueFetching }) =>
+    !continueFetching &&
+    `
+    display: none !important;
+  `}
 `;

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -121,8 +121,10 @@ export const PostPage = () => {
     }
   };
 
-  const handleCommentListRefresh = async (newCommentList: Comment[]) => {
-    setCommentList(newCommentList);
+  const handleCommentListRefresh = async () => {
+    setCommentList([]);
+    setCommentListPage(0);
+    setContinueFetching(true);
   };
 
   const handleCommentFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -135,8 +137,7 @@ export const PostPage = () => {
       }
       if (params.postIdx) {
         await board.createComment(params.postIdx, { contents: comment });
-        const fetchedData = await board.getPostData(params.postIdx);
-        handleCommentListRefresh(fetchedData.comments);
+        handleCommentListRefresh();
       }
     } catch (err) {
       const error = err as CustomError;
@@ -322,6 +323,6 @@ const CommentListBottom = styled.div<CommentListBottomProps>`
   ${({ continueFetching }) =>
     !continueFetching &&
     `
-    visibility: hidden !important;
+    display: none !important;
   `}
 `;

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { Browser } from 'components/common/Browser';
 import { Button } from 'components/common/Button';
@@ -17,6 +17,7 @@ import { board } from 'api/board';
 import { auth } from 'api/auth';
 import { CommentForm } from 'components/board/CommentForm';
 import { member } from 'api/member';
+import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
 interface FunctionButtonsProps {
   postIdx: string;
@@ -31,12 +32,22 @@ interface FunctionButtonProps {
 export const PostPage = () => {
   const [currentUserData, setCurrentUserData] = useState<Member>();
   const [postData, setPostData] = useState<Post>();
-  const [commentList, setCommentList] = useState<Comment[]>();
+  const [commentList, setCommentList] = useState<Comment[]>([]);
+  const [continueFetching, setContinueFetching] = useState<boolean>(true);
+  const [commentListPage, setCommentListPage] = useState<number>(0);
   const {
     inputValue: comment,
     handleInputChange: handleCommentChange,
     handleResetInput: handleCommentReset,
   } = useInput('');
+  const intersectRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const { isIntersect } = useIntersectionObserver(intersectRef, {
+    root: rootRef.current,
+    rootMargin: '50px',
+    threshold: 0.01,
+  });
+  const COUNT = 5;
   const params = useParams();
   const navigate = useNavigate();
 

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -66,6 +66,14 @@ export const PostPage = () => {
     }
   }, [commentListPage]);
 
+  useEffect(() => {
+    if (isIntersect && commentListPage >= 0) {
+      setCommentListPage((prev) => {
+        return prev + COUNT;
+      });
+    }
+  }, [isIntersect]);
+
   const fetchUserData = async () => {
     try {
       const fetchedData = await member.getMemberInfo();

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -29,6 +29,10 @@ interface FunctionButtonProps {
   children: React.ReactNode;
 }
 
+interface CommentListBottomProps {
+  continueFetching: boolean;
+}
+
 export const PostPage = () => {
   const [currentUserData, setCurrentUserData] = useState<Member>();
   const [postData, setPostData] = useState<Post>();
@@ -148,6 +152,9 @@ export const PostPage = () => {
                 ) : (
                   <NoComment />
                 )}
+                <CommentListBottom continueFetching={continueFetching} ref={intersectRef}>
+                  Loading...
+                </CommentListBottom>
               </CommentList>
             </CommentContainer>
           </PostContainer>
@@ -276,3 +283,11 @@ export const CommentContainer = styled.div`
 `;
 
 const CommentList = styled.div``;
+
+const CommentListBottom = styled.div<CommentListBottomProps>`
+  ${({ continueFetching }) =>
+    !continueFetching &&
+    `
+    visibility: hidden !important;
+  `}
+`;

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -60,6 +60,12 @@ export const PostPage = () => {
     fetchUserData();
   }, []);
 
+  useEffect(() => {
+    if (continueFetching) {
+      fetchCommentList();
+    }
+  }, [commentListPage]);
+
   const fetchUserData = async () => {
     try {
       const fetchedData = await member.getMemberInfo();
@@ -74,7 +80,6 @@ export const PostPage = () => {
       if (params.postIdx) {
         const fetchedData = await board.getPostData(params.postIdx);
         setPostData(fetchedData);
-        setCommentList(fetchedData.comments);
       } else {
         alert('게시글이 존재하지 않습니다.');
         navigate(-1);
@@ -83,6 +88,27 @@ export const PostPage = () => {
       const error = err as CustomError;
       alert(error.message);
       navigate(-1);
+      return;
+    }
+  };
+
+  const fetchCommentList = async () => {
+    try {
+      if (params.postIdx) {
+        const fetchedData = await board.getCommentList(params.postIdx, commentListPage, COUNT);
+        if (fetchedData.length === 0) {
+          setContinueFetching(false);
+          return;
+        }
+        setCommentList((prev) => [...prev, ...fetchedData]);
+      } else {
+        alert('게시글이 존재하지 않습니다.');
+        navigate(-1);
+      }
+    } catch (err) {
+      const error = err as CustomError;
+      alert(error.message);
+      navigate('/');
       return;
     }
   };

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -111,7 +111,7 @@ export const PostPage = () => {
   return (
     <Layout>
       <BrowserWrapper>
-        <Browser>
+        <Browser ref={rootRef}>
           <PostContainer>
             {postData && (
               <div>


### PR DESCRIPTION
# What is this PR?🔍
- 댓글 목록 무한 스크롤 기능 구현

# Changes✨
- query string으로 start, count 값을 받아서 댓글 목록을 5개씩 불러오는 getCommentList 메소드 생성
- Browser 컴포넌트를 root 요소로 하는 IntersectionObserver 객체 생성하여 target(CommentListBottom)의 교차 여부를 isIntersect로 판별
- CommentListBottom이 root 요소와 교차했을 때 commentListPage를 증가
  - commentListPage를 dependency array에 담은 useEffect 내 fetchCommentList를 트리거
- handleCommentListRefresh 함수 수정
  - 댓글 작성 시 댓글 목록을 새로고침하기 위한 함수
# Screenshot📸
![pr_image](https://user-images.githubusercontent.com/67324487/218964932-7b71b454-0f11-450a-ab65-5c5a97806e08.gif)

# To reviewers🕵🏻‍♂️
-

Closes #issue.no