### PR TITLE
Feat: 자신이 작성한 게시글 목록 무한 스크롤 구현

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -19,7 +19,7 @@ const member = {
       if (start >= 0 && count >= 0) {
         memberPostsData = await axios.get(`/member/posts?start=${start}&count=${count}`, { withCredentials: true });
       } else {
-        memberPostsData = await axios.get(`/post/list`, { withCredentials: true });
+        memberPostsData = await axios.get(`/member/posts`, { withCredentials: true });
       }
       return memberPostsData.data.data;
     } catch {

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -13,9 +13,14 @@ const member = {
       };
     }
   },
-  getMemberPosts: async () => {
+  getMemberPosts: async (start: number, count: number) => {
     try {
-      const memberPostsData = await axios.get(`/member/posts`, { withCredentials: true });
+      let memberPostsData;
+      if (start >= 0 && count >= 0) {
+        memberPostsData = await axios.get(`/member/posts?start=${start}&count=${count}`, { withCredentials: true });
+      } else {
+        memberPostsData = await axios.get(`/post/list`, { withCredentials: true });
+      }
       return memberPostsData.data.data;
     } catch {
       throw {

--- a/src/components/board/CommentItem.tsx
+++ b/src/components/board/CommentItem.tsx
@@ -12,7 +12,7 @@ import { board } from 'api/board';
 interface CommentItemProps {
   data: Comment;
   isCommentWriter: boolean;
-  commentListRefreshHandler: (newCommentList: Comment[]) => void;
+  commentListRefreshHandler: () => void;
 }
 
 export const CommentItem = ({ data, isCommentWriter, commentListRefreshHandler }: CommentItemProps) => {
@@ -36,8 +36,7 @@ export const CommentItem = ({ data, isCommentWriter, commentListRefreshHandler }
       }
       if (params.postIdx) {
         await board.modifyComment(params.postIdx, data.comment_idx, { contents: modifiedComment });
-        const fetchedData = await board.getPostData(params.postIdx);
-        commentListRefreshHandler(fetchedData.comments);
+        commentListRefreshHandler();
       }
     } catch (err) {
       const error = err as CustomError;
@@ -53,8 +52,7 @@ export const CommentItem = ({ data, isCommentWriter, commentListRefreshHandler }
       if (confirm('댓글을 삭제하시겠습니까?')) {
         if (params.postIdx) {
           await board.deleteComment(params.postIdx, data.comment_idx);
-          const fetchedData = await board.getPostData(params.postIdx);
-          commentListRefreshHandler(fetchedData.comments);
+          commentListRefreshHandler();
         }
       } else {
         return;

--- a/src/components/layouts/Menu.tsx
+++ b/src/components/layouts/Menu.tsx
@@ -54,7 +54,7 @@ export const Menu = memo(({ menuRef, startButtonClickHandler }: MenuProps) => {
       <MenuWrapper>
         <MenuBox>
           <MenuImage src={SourceCodeImg} alt="source_code_image" />
-          <a href="https://github.com/nvrtmd/react-membership-board" target="_blank">
+          <a href="https://github.com/nvrtmd/react-membership-board-ts" target="_blank">
             Source Code
           </a>
         </MenuBox>

--- a/src/pages/board/ListPage.tsx
+++ b/src/pages/board/ListPage.tsx
@@ -51,7 +51,7 @@ export const ListPage = () => {
   }, [postListPage]);
 
   useEffect(() => {
-    if (isIntersect && postListPage >= 0) {
+    if (isIntersect && postList.length && postListPage >= 0) {
       setPostListPage((prev) => {
         return prev + COUNT;
       });

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -67,7 +67,7 @@ export const PostPage = () => {
   }, [commentListPage]);
 
   useEffect(() => {
-    if (isIntersect && commentListPage >= 0) {
+    if (isIntersect && commentList.length && commentListPage >= 0) {
       setCommentListPage((prev) => {
         return prev + COUNT;
       });

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -46,6 +46,7 @@ export const PostPage = () => {
   } = useInput('');
   const intersectRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const commentListTop = useRef<HTMLDivElement>(null);
   const { isIntersect } = useIntersectionObserver(intersectRef, {
     root: rootRef.current,
     rootMargin: '50px',
@@ -125,6 +126,9 @@ export const PostPage = () => {
     setCommentList([]);
     setCommentListPage(0);
     setContinueFetching(true);
+    commentListTop.current?.scrollIntoView({
+      behavior: 'smooth',
+    });
   };
 
   const handleCommentFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -175,6 +179,7 @@ export const PostPage = () => {
                 formTitle="Comments"
               />
               <CommentList>
+                <div ref={commentListTop}></div>
                 {commentList && commentList.length > 0 ? (
                   commentList.map((comment) => (
                     <CommentItem

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -34,7 +34,7 @@ export const MyPostsPage = () => {
   }, [postListPage]);
 
   useEffect(() => {
-    if (isIntersect && postListPage >= 0) {
+    if (isIntersect && postList.length && postListPage >= 0) {
       setPostListPage((prev) => {
         return prev + COUNT;
       });

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -9,6 +9,10 @@ import { PostItem } from 'components/board/PostItem';
 import { NoPost } from 'components/common/NoPost';
 import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
+interface PostListBottomProps {
+  continueFetching: boolean;
+}
+
 export const MyPostsPage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
   const [postListPage, setPostListPage] = useState<number>(0);
@@ -63,6 +67,9 @@ export const MyPostsPage = () => {
               <NoPost />
             )}
           </ListWrapper>
+          <PostListBottom continueFetching={continueFetching} ref={intersectRef}>
+            Loading...
+          </PostListBottom>
         </Browser>
       </BrowserWrapper>
     </Layout>
@@ -81,4 +88,12 @@ const ListWrapper = styled.div`
   table-layout: fixed;
   width: 100%;
   height: inherit;
+`;
+
+const PostListBottom = styled.div<PostListBottomProps>`
+  ${({ continueFetching }) =>
+    !continueFetching &&
+    `
+    display: none !important;
+  `}
 `;

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -55,7 +55,7 @@ export const MyPostsPage = () => {
   return (
     <Layout>
       <BrowserWrapper>
-        <Browser>
+        <Browser ref={rootRef}>
           <ListWrapper>
             {postList && postList.length > 0 ? (
               postList.map((post) => <PostItem data={post} clickHandler={moveToPost} key={post.post_idx} />)

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -28,8 +28,10 @@ export const MyPostsPage = () => {
   const COUNT = 5;
 
   useEffect(() => {
-    fetchPostList();
-  }, []);
+    if (continueFetching) {
+      fetchPostList();
+    }
+  }, [postListPage]);
 
   const fetchPostList = async () => {
     try {
@@ -40,8 +42,12 @@ export const MyPostsPage = () => {
     }
 
     try {
-      const fetchedData = await member.getMemberPosts();
-      setPostList(fetchedData);
+      const fetchedData = await member.getMemberPosts(postListPage, COUNT);
+      if (fetchedData.length === 0) {
+        setContinueFetching(false);
+        return;
+      }
+      setPostList((prev) => [...prev, ...fetchedData]);
     } catch (err) {
       const error = err as CustomError;
       alert(error.message);

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -33,6 +33,14 @@ export const MyPostsPage = () => {
     }
   }, [postListPage]);
 
+  useEffect(() => {
+    if (isIntersect && postListPage >= 0) {
+      setPostListPage((prev) => {
+        return prev + COUNT;
+      });
+    }
+  }, [isIntersect]);
+
   const fetchPostList = async () => {
     try {
       await member.getMemberInfo();

--- a/src/pages/member/MyPostsPage.tsx
+++ b/src/pages/member/MyPostsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { Browser } from 'components/common/Browser';
@@ -7,10 +7,21 @@ import { CustomError, Post } from 'global/types';
 import { member } from 'api/member';
 import { PostItem } from 'components/board/PostItem';
 import { NoPost } from 'components/common/NoPost';
+import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
 export const MyPostsPage = () => {
-  const [postList, setPostList] = useState<Post[]>();
+  const [postList, setPostList] = useState<Post[]>([]);
+  const [postListPage, setPostListPage] = useState<number>(0);
+  const [continueFetching, setContinueFetching] = useState<boolean>(true);
   const navigate = useNavigate();
+  const intersectRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const { isIntersect } = useIntersectionObserver(intersectRef, {
+    root: rootRef.current,
+    rootMargin: '50px',
+    threshold: 0.01,
+  });
+  const COUNT = 5;
 
   useEffect(() => {
     fetchPostList();


### PR DESCRIPTION
# What is this PR?🔍
- 자신이 작성한 게시글 목록 무한 스크롤 구현

# Changes✨
- PostList, CommentList와 동일한 방식으로 무한 스크롤 구현

- 추가 수정 사안
  - PostList, CommentList, MyPostsList에서 data fetch가 일어나지 않았는데 intersectRef 요소가 화면에 표시되어 바로 page에 +5가 되어 data fetch가 한번 더 일어나는 것을 방지하기 위해 setPage가 실행되는 조건문에 조건 추가
    - 예를 들어 PostList의 경우 postList.length가 0 이하인 경우 setPostListPage(...)가 일어나지 않도록 함
# Screenshot📸
![pr_image](https://user-images.githubusercontent.com/67324487/218994687-fbfa7795-ef67-429b-819d-3942b7286bdf.gif)


# To reviewers🕵🏻‍♂️
-

Closes #issue.no