### PR TITLE
Fix: 댓글 0개일 때 댓글 작성 시 댓글이 표시되지 않는 버그

### DIFF
--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -46,7 +46,7 @@ export const PostPage = () => {
   } = useInput('');
   const intersectRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-  const commentListTop = useRef<HTMLDivElement>(null);
+  const commentContainerTop = useRef<HTMLDivElement>(null);
   const { isIntersect } = useIntersectionObserver(intersectRef, {
     root: rootRef.current,
     rootMargin: '50px',
@@ -130,7 +130,7 @@ export const PostPage = () => {
     }
     setCommentList([]);
     setContinueFetching(true);
-    commentListTop.current?.scrollIntoView({
+    commentContainerTop.current?.scrollIntoView({
       behavior: 'smooth',
     });
   };
@@ -179,6 +179,7 @@ export const PostPage = () => {
                 <FunctionButtons postIdx={String(postData.post_idx)} />
               </div>
             )}
+            <div ref={commentContainerTop}></div>
             <CommentContainer>
               <CommentForm
                 submitHandler={handleCommentFormSubmit}
@@ -187,7 +188,6 @@ export const PostPage = () => {
                 formTitle="Comments"
               />
               <CommentList>
-                <div ref={commentListTop}></div>
                 {commentList && commentList.length > 0 ? (
                   commentList.map((comment) => (
                     <CommentItem

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -123,8 +123,12 @@ export const PostPage = () => {
   };
 
   const handleCommentListRefresh = async () => {
+    if (commentListPage > 0) {
+      setCommentListPage(0);
+    } else {
+      fetchCommentList();
+    }
     setCommentList([]);
-    setCommentListPage(0);
     setContinueFetching(true);
     commentListTop.current?.scrollIntoView({
       behavior: 'smooth',

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -141,7 +141,11 @@ export const PostPage = () => {
       }
       if (params.postIdx) {
         await board.createComment(params.postIdx, { contents: comment });
-        handleCommentListRefresh();
+        if (commentList.length === 0) {
+          fetchCommentList();
+        } else {
+          handleCommentListRefresh();
+        }
       }
     } catch (err) {
       const error = err as CustomError;


### PR DESCRIPTION
# What is this PR?🔍
- 댓글 0개일 때 댓글 작성 시 댓글이 표시되지 않는 버그 해결

# Changes✨
- handleCommentFormSubmit에서 댓글 작성 API 호출 후 handleCommentListRefresh가 실행될 때 setCommentListPage(0)를 실행해도 fetchCommentList()가 실행되지 않음
  - 이유: 기존에 commentListPage가 0이었으므로 state에 변화가 없어서 아래 useEffect가 trigger되지 않으므로 댓글 목록도 refresh되지 않아서 작성한 댓글이 표시되지 않았음
```
  useEffect(() => {
    if (continueFetching) {
      fetchCommentList();
    }
  }, [commentListPage]);
```
- 해결
  - commentList의 길이가 0일 경우 handleCommentFormSubmit 함수 내에서 댓글 작성 API 호출 후에 fetchCommentList 함수를 실행
  - commentListPage가 0 이하일 경우 handleCommentListRefresh 내에서 fetchCommentList 실행

- 추가 수정 사안
  - commentListTop의 위치를 CommentContainer 위로 옮기면서 이름을 commentContainerTop로 수정
# Screenshot📸
![pr_image](https://user-images.githubusercontent.com/67324487/219113012-3fbc81d0-0a24-4b1a-b00d-abcbc7b2ce6a.gif)


# To reviewers🕵🏻‍♂️
-

Closes #72 