### PR TITLE
Feat: 자신이 작성한 게시글의 상세 페이지에만 삭제 및 수정 버튼 표시

### DIFF
--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -47,7 +47,7 @@ export const PostPage = () => {
   } = useInput('');
   const intersectRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-  const commentContainerTop = useRef<HTMLDivElement>(null);
+  const postContainerTop = useRef<HTMLDivElement>(null);
   const { isIntersect } = useIntersectionObserver(intersectRef, {
     root: rootRef.current,
     rootMargin: '50px',
@@ -131,7 +131,7 @@ export const PostPage = () => {
     }
     setCommentList([]);
     setContinueFetching(true);
-    commentContainerTop.current?.scrollIntoView({
+    postContainerTop.current?.scrollIntoView({
       behavior: 'smooth',
     });
   };
@@ -164,6 +164,7 @@ export const PostPage = () => {
     <Layout>
       <BrowserWrapper>
         <Browser ref={rootRef}>
+          <div ref={postContainerTop}></div>
           <PostContainer>
             {postData && (
               <div>
@@ -183,7 +184,6 @@ export const PostPage = () => {
                 />
               </div>
             )}
-            <div ref={commentContainerTop}></div>
             <CommentContainer>
               <CommentForm
                 submitHandler={handleCommentFormSubmit}

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -21,6 +21,7 @@ import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 
 interface FunctionButtonsProps {
   postIdx: string;
+  isPostWriter: boolean;
 }
 
 interface FunctionButtonProps {
@@ -34,7 +35,7 @@ interface CommentListBottomProps {
 }
 
 export const PostPage = () => {
-  const [currentUserData, setCurrentUserData] = useState<Member>();
+  const [currentUserData, setCurrentUserData] = useState<Member | null>(null);
   const [postData, setPostData] = useState<Post>();
   const [commentList, setCommentList] = useState<Comment[]>([]);
   const [continueFetching, setContinueFetching] = useState<boolean>(true);
@@ -176,7 +177,10 @@ export const PostPage = () => {
                   </PostUpdatedDate>
                 </PostHeader>
                 <PostBody>{postData.post_contents}</PostBody>
-                <FunctionButtons postIdx={String(postData.post_idx)} />
+                <FunctionButtons
+                  postIdx={String(postData.post_idx)}
+                  isPostWriter={currentUserData?.id === postData.post_writer.member_id}
+                />
               </div>
             )}
             <div ref={commentContainerTop}></div>
@@ -212,7 +216,7 @@ export const PostPage = () => {
   );
 };
 
-const FunctionButtons = ({ postIdx }: FunctionButtonsProps) => {
+const FunctionButtons = ({ postIdx, isPostWriter }: FunctionButtonsProps) => {
   const navigate = useNavigate();
   const params = useParams();
   const location = useLocation();
@@ -257,12 +261,16 @@ const FunctionButtons = ({ postIdx }: FunctionButtonsProps) => {
 
   return (
     <FunctionButtonsWrapper>
-      <FunctionButton handleFunctionButtonRestore={() => handleFunctionButtonRestore('Delete')} name="Delete">
-        <FunctionButtonImage src={DeletePostImg} />
-      </FunctionButton>
-      <FunctionButton handleFunctionButtonRestore={() => handleFunctionButtonRestore('Modify')} name="Modify">
-        <FunctionButtonImage src={ModifyPostImg} />
-      </FunctionButton>
+      {isPostWriter && (
+        <>
+          <FunctionButton handleFunctionButtonRestore={() => handleFunctionButtonRestore('Delete')} name="Delete">
+            <FunctionButtonImage src={DeletePostImg} />
+          </FunctionButton>
+          <FunctionButton handleFunctionButtonRestore={() => handleFunctionButtonRestore('Modify')} name="Modify">
+            <FunctionButtonImage src={ModifyPostImg} />
+          </FunctionButton>
+        </>
+      )}
       <FunctionButton handleFunctionButtonRestore={() => handleFunctionButtonRestore('List')} name="List">
         <FunctionButtonImage src={BackToPostListImg} />
       </FunctionButton>


### PR DESCRIPTION
# What is this PR?🔍
- 자신이 작성한 게시글의 상세 페이지에만 삭제 및 수정 버튼 표시

# Changes✨
- 게시글 상세 페이지에 접근했을 때 API 호출을 통해 할당된 현재 사용자의 정보 currentUserData state와 게시글 작성자 정보를 비교(id로 비교)하여 서로 같을 때에만 삭제 및 수정 버튼 표시

- 추가 구현 사안
  - commentContainerTop을 아예 게시글 맨 위로 올리기
    - 댓글 목록이 새로고침 되었을 때 하단 댓글 loading 영역이 드러나는 것을 방지

# Screenshot📸
![image](https://user-images.githubusercontent.com/67324487/219282676-99c08222-295c-41c7-a4ea-59787f75cfd9.png)


# To reviewers🕵🏻‍♂️
-

Closes #74