### PR TITLE
Feat: 비로그인 사용자의 경우 댓글 작성 영역 비활성화

### DIFF
--- a/src/components/board/CommentForm.tsx
+++ b/src/components/board/CommentForm.tsx
@@ -10,6 +10,7 @@ interface CommentFormProps {
   formTitle?: string;
   type?: string;
   commentModifyCancelHandler?: () => void;
+  isDisabled?: boolean;
 }
 
 export const CommentForm = ({
@@ -19,6 +20,7 @@ export const CommentForm = ({
   formTitle,
   type,
   commentModifyCancelHandler,
+  isDisabled,
 }: CommentFormProps) => {
   return (
     <Form onSubmit={submitHandler}>
@@ -33,13 +35,14 @@ export const CommentForm = ({
           name="comment"
           changeHandler={commentChangeHandler}
           value={commentValue}
+          isDisabled={isDisabled}
         />
       </ContentsWrapper>
       <ButtonWrapper>
         {type === 'commentModifyForm' && (
           <Button name="Cancel" type="button" restoreHandler={commentModifyCancelHandler} />
         )}
-        <Button name="Write" type="submit" />
+        <Button name="Write" type="submit" isDisabled={isDisabled} />
       </ButtonWrapper>
     </Form>
   );

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,13 +7,15 @@ interface ButtonProps {
   name?: string;
   children?: React.ReactNode;
   type: 'button' | 'submit' | 'reset';
+  isDisabled?: boolean;
 }
 
 interface ButtonWrapperProps {
   isPushed: boolean;
+  isDisabled?: boolean;
 }
 
-export const Button = memo(({ pushHandler, restoreHandler, name, children, type }: ButtonProps) => {
+export const Button = memo(({ pushHandler, restoreHandler, name, children, type, isDisabled }: ButtonProps) => {
   const [isPushed, setIsPushed] = useState<boolean>(false);
 
   const handleButtonPush = () => {
@@ -40,6 +42,7 @@ export const Button = memo(({ pushHandler, restoreHandler, name, children, type 
       onMouseUp={handleButtonRestore}
       onMouseOut={handleButtonMouseOut}
       type={type}
+      disabled={isDisabled}
     >
       {children}
       {name}
@@ -60,6 +63,13 @@ const ButtonWrapper = styled.button<ButtonWrapperProps>`
   box-shadow: 3px 3px 0px 0px #dfdfdf inset, -3px -3px 0px 0px #808080 inset;
   -webkit-box-shadow: 3px 3px 0px 0px #dfdfdf inset, -3px -3px 0px 0px #808080 inset;
   -moz-box-shadow: 3px 3px 0px 0px #dfdfdf inset, -3px -3px 0px 0px #808080 inset;
+  ${({ disabled }) =>
+    disabled &&
+    `
+    box-shadow: 3px 3px 0px 0px #808080 inset, -3px -3px 0px 0px #dfdfdf inset;
+    -webkit-box-shadow: 3px 3px 0px 0px #808080 inset, -3px -3px 0px 0px #dfdfdf inset;
+    -moz-box-shadow: 3px 3px 0px 0px #808080 inset, -3px -3px 0px 0px #dfdfdf inset;
+  `}
   ${({ isPushed }) =>
     isPushed &&
     `

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -36,4 +36,7 @@ const TextAreaBox = styled.textarea`
   height: 100%;
   font-size: 1.2rem;
   font-family: DungGeunMo;
+  &:focus {
+    background: ${theme.color.white};
+  }
 `;

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -1,14 +1,24 @@
 import styled from 'styled-components/macro';
+import { theme } from 'styles/theme';
 
 interface TextAreaProps {
   placeholder: string;
   name: string;
   changeHandler: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   value: string | number;
+  isDisabled?: boolean;
 }
 
-export const TextArea = ({ placeholder, name, changeHandler, value }: TextAreaProps) => {
-  return <TextAreaBox name={name} placeholder={placeholder} onChange={changeHandler} value={value} />;
+export const TextArea = ({ placeholder, name, changeHandler, value, isDisabled }: TextAreaProps) => {
+  return (
+    <TextAreaBox
+      name={name}
+      placeholder={isDisabled ? 'Only signed in users can post comment' : placeholder}
+      onChange={changeHandler}
+      value={value}
+      disabled={isDisabled}
+    />
+  );
 };
 
 const TextAreaBox = styled.textarea`
@@ -18,6 +28,7 @@ const TextAreaBox = styled.textarea`
   outline: none;
   resize: none;
   background: none;
+  background: ${theme.color.lightGrey};
   box-shadow: 2px 2px 0px 0px #808080 inset, -2px -2px 0px 0px #dfdfdf inset;
   -webkit-box-shadow: 2px 2px 0px 0px #808080 inset, -2px -2px 0px 0px #dfdfdf inset;
   -moz-box-shadow: 2px 2px 0px 0px #808080 inset, -2px -2px 0px 0px #dfdfdf inset;

--- a/src/pages/board/PostPage.tsx
+++ b/src/pages/board/PostPage.tsx
@@ -190,6 +190,7 @@ export const PostPage = () => {
                 commentValue={comment}
                 commentChangeHandler={handleCommentChange}
                 formTitle="Comments"
+                isDisabled={currentUserData === null}
               />
               <CommentList>
                 {commentList && commentList.length > 0 ? (


### PR DESCRIPTION
# What is this PR?🔍
- 비로그인 사용자의 경우 댓글 작성 영역 비활성화

# Changes✨
- TextArea, Button에 isDisabled props 추가
- textarea, button 내 disabled 속성 추가
  - props로 받은 isDisabled를 할당
- PostPage의 CommentForm에 currentUserData === null를 isDisabled props로 전달
  - 비로그인 사용자의 경우 isDiabled에 true가 할당됨

- 추가 구현 사안
  -  로그인 된 사용자가 TextArea 클릭 시(focus) TextArea background color을 lightGrey에서 white로 변경

Screenshot📸
![image](https://user-images.githubusercontent.com/67324487/219299758-47522a8b-cd73-408b-8bd3-6bc5d18b966f.png)


# To reviewers🕵🏻‍♂️
-

Closes #76 