### PR TITLE
Fix: 댓글 수정 시 수정된 댓글 내용이 반영되지 않는 오류

### DIFF
--- a/src/components/board/CommentItem.tsx
+++ b/src/components/board/CommentItem.tsx
@@ -25,12 +25,15 @@ interface CommentBodyProps {
 
 export const CommentItem = ({ data, isCommentWriter, commentListRefreshHandler }: CommentItemProps) => {
   const [isModifyButtonClicked, setIsModifyButtonClicked] = useState<boolean>(false);
-  const { inputValue: modifiedComment, handleInputChange: handleModifiedCommentChange } = useInput(
-    data.comment_contents,
-  );
+  const {
+    inputValue: modifiedComment,
+    handleInputChange: handleModifiedCommentChange,
+    setInputValue: setModifiedComment,
+  } = useInput(data.comment_contents);
   const params = useParams();
 
   const handleIsModifyButtonClickedToggle = useCallback(() => {
+    setModifiedComment(data.comment_contents);
     setIsModifyButtonClicked((prev) => !prev);
   }, []);
 

--- a/src/components/board/CommentItem.tsx
+++ b/src/components/board/CommentItem.tsx
@@ -34,25 +34,28 @@ export const CommentItem = ({ data, isCommentWriter, commentListRefreshHandler }
     setIsModifyButtonClicked((prev) => !prev);
   }, []);
 
-  const handleCommentModifyFormSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    try {
-      await auth.isSignedIn();
-      if (modifiedComment.length <= 0) {
-        alert(BOARD_ALERT_MESSAGE.CONTENTS_EMPTY_ALERT);
+  const handleCommentModifyFormSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      try {
+        await auth.isSignedIn();
+        if (modifiedComment.length <= 0) {
+          alert(BOARD_ALERT_MESSAGE.CONTENTS_EMPTY_ALERT);
+          return;
+        }
+        if (params.postIdx) {
+          await board.modifyComment(params.postIdx, data.comment_idx, { contents: modifiedComment });
+          commentListRefreshHandler();
+        }
+      } catch (err) {
+        const error = err as CustomError;
+        alert(error.message);
         return;
       }
-      if (params.postIdx) {
-        await board.modifyComment(params.postIdx, data.comment_idx, { contents: modifiedComment });
-        commentListRefreshHandler();
-      }
-    } catch (err) {
-      const error = err as CustomError;
-      alert(error.message);
-      return;
-    }
-    handleIsModifyButtonClickedToggle();
-  }, []);
+      handleIsModifyButtonClickedToggle();
+    },
+    [modifiedComment],
+  );
 
   return (
     <CommentsWrapper>


### PR DESCRIPTION
# What is this PR?🔍
- 댓글 수정 시 수정된 댓글 내용이 반영되지 않는 오류

# Changes✨
- 댓글 수정 버튼 클릭 시 실행되는 함수를 감싼 useCallback의 dependency array에 수정된 댓글 내용을 담은 state를 추가하여 최신 상태를 반영
- 추가 수정 사안
  - 댓글 수정 취소 후 다시 수정 버튼 클릭할 경우 이전에 수정하던 내용이 남아있는 오류를 수정
    - 수정 취소 버튼 클릭 시 setState를 사용하여 modifiedComment를 수정되기 전 댓글 내용으로 원복

# Screenshot📸
```
  const handleIsModifyButtonClickedToggle = useCallback(() => {
    setModifiedComment(data.comment_contents);
    setIsModifyButtonClicked((prev) => !prev);
  }, []);

  const handleCommentModifyFormSubmit = useCallback(
    async (e: React.FormEvent<HTMLFormElement>) => {
      e.preventDefault();
      try {
        await auth.isSignedIn();
        if (modifiedComment.length <= 0) {
          alert(BOARD_ALERT_MESSAGE.CONTENTS_EMPTY_ALERT);
          return;
        }
        if (params.postIdx) {
          await board.modifyComment(params.postIdx, data.comment_idx, { contents: modifiedComment });
          commentListRefreshHandler();
        }
      } catch (err) {
        const error = err as CustomError;
        alert(error.message);
        return;
      }
      handleIsModifyButtonClickedToggle();
    },
    [modifiedComment],
  );
// ...
};
```

# To reviewers🕵🏻‍♂️
-

Closes #93 