### PR TITLE
Feat: 회원 가입 및 회원 정보 수정 시 아이디 중복 에러 처리 추가

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { member } from 'apis/member';
 import { AUTH_ERROR_MESSAGE } from 'constants/constants';
 import { Member } from 'global/types';
@@ -7,11 +7,16 @@ const auth = {
   signUp: async (data: Member) => {
     try {
       await axios.post(`/auth/signup`, data);
-    } catch {
-      throw {
-        code: 500,
-        message: AUTH_ERROR_MESSAGE.DUPLICATED_ID,
-      };
+    } catch (err) {
+      const error = err as AxiosError;
+      switch (error.response?.status) {
+        case 409:
+          throw { code: 409, message: AUTH_ERROR_MESSAGE.DUPLICATED_ID };
+        case 500:
+          throw { code: 500, message: AUTH_ERROR_MESSAGE.CANNOT_SIGN_UP };
+        default:
+          throw { code: 500, message: AUTH_ERROR_MESSAGE.CANNOT_SIGN_UP };
+      }
     }
   },
   signIn: async (data: Member) => {

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { MEMBER_ERROR_MESSAGE } from 'constants/constants';
 import { Member } from 'global/types';
 
@@ -33,11 +33,16 @@ const member = {
   modifyMemberInfo: async (data: Member) => {
     try {
       await axios.patch(`/member/info`, data, { withCredentials: true });
-    } catch {
-      throw {
-        code: 500,
-        message: MEMBER_ERROR_MESSAGE.CANNOT_MODIFY_MEMBER_INFO,
-      };
+    } catch (err) {
+      const error = err as AxiosError;
+      switch (error.response?.status) {
+        case 409:
+          throw { code: 409, message: MEMBER_ERROR_MESSAGE.DUPLICATED_ID };
+        case 500:
+          throw { code: 500, message: MEMBER_ERROR_MESSAGE.CANNOT_MODIFY_MEMBER_INFO };
+        default:
+          throw { code: 500, message: MEMBER_ERROR_MESSAGE.CANNOT_MODIFY_MEMBER_INFO };
+      }
     }
   },
   deleteAccount: async () => {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -6,6 +6,7 @@ export const MEMBER_ALERT_MESSAGE = {
 };
 
 export const MEMBER_ERROR_MESSAGE = {
+  DUPLICATED_ID: '중복된 아이디가 존재합니다. 아이디를 수정해주세요.',
   CANNOT_GET_MEMBER_INFO_FROM_SERVER: '서버로부터 회원 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
   CANNOT_GET_MEMBER_POSTS_FROM_SERVER: '서버로부터 회원 게시글 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
   CANNOT_MODIFY_MEMBER_INFO: '회원 정보 수정에 실패하였습니다. 잠시 후 다시 시도해주세요.',
@@ -21,6 +22,7 @@ export const AUTH_ERROR_MESSAGE = {
   DUPLICATED_ID: '중복된 아이디가 존재합니다.',
   NOT_EXISTED_ID_OR_PASSWORD: '존재하지 않는 아이디 또는 비밀번호입니다.',
   CANNOT_SIGN_OUT: '로그아웃에 실패하였습니다. 잠시 후 다시 시도해주세요.',
+  CANNOT_SIGN_UP: '회원가입에 실패하였습니다. 잠시 후 다시 시도해주세요.',
   NEED_SIGN_IN: '로그인이 필요합니다.',
 };
 


### PR DESCRIPTION
# What is this PR?🔍
- 회원 가입 및 회원 정보 수정 시 아이디 중복 에러 처리 추가

# Changes✨
- constants 파일 내 에러 메세지 추가
- signUp, modifyMemberInfo 메소드에서 switch문을 통해 status code에 따라 다른 에러 메세지를 담아 throw하도록 함
# Screenshot📸
![Uploading image.png…]()


# To reviewers🕵🏻‍♂️
-

Closes #93 